### PR TITLE
No longer pulls down install script, allows user to keep or delete folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ on a important directory. You can restore the last removed file/directory with *
 
 ## Installation
 
-To install rm-v2, paste and run the following line in your terminal.
+To install rm-v2, paste and run the following commands in your terminal.
 
-    python -c "$(curl -fsSL https://raw.githubusercontent.com/SudhagarS/rm-v2/master/install)"
+    git clone https://github.com/SudhagarS/rm-v2/
+    
+    sudo mv rm-v2/rm /usr/local/bin/
+    
+    chmod u+x /usr/local/bin/rm
+    
+To remove the downloaded files once installed run
+    
+    rm -rf rm-v2
     
     
 ## Usage


### PR DESCRIPTION
It doesn't pull the install script off of git anymore, instead it gives the user the commands to install it (Meaning the user won't have to read thru the installer to see what's happening, and that this can be mirrored else where and the user will still know how to install it.)
